### PR TITLE
Reorder font definitions

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,26 +27,26 @@ flutter:
     # in all platforms, to ensure we can use it, we provide it as an asset as well
     - family: Roboto
       fonts:
+        - asset: assets/fonts/Roboto/Roboto-Regular.ttf
+          weight: 400
         - asset: assets/fonts/Roboto/Roboto-Thin.ttf
           weight: 100
         - asset: assets/fonts/Roboto/Roboto-Light.ttf
           weight: 300
-        - asset: assets/fonts/Roboto/Roboto-Regular.ttf
-          weight: 400
         - asset: assets/fonts/Roboto/Roboto-Medium.ttf
           weight: 500
         - asset: assets/fonts/Roboto/Roboto-Bold.ttf
           weight: 700
         - asset: assets/fonts/Roboto/Roboto-Black.ttf
           weight: 900
+        - asset: assets/fonts/Roboto/Roboto-RegularItalic.ttf
+          weight: 400
+          style: italic
         - asset: assets/fonts/Roboto/Roboto-ThinItalic.ttf
           weight: 100
           style: italic
         - asset: assets/fonts/Roboto/Roboto-LightItalic.ttf
           weight: 300
-          style: italic
-        - asset: assets/fonts/Roboto/Roboto-RegularItalic.ttf
-          weight: 400
           style: italic
         - asset: assets/fonts/Roboto/Roboto-MediumItalic.ttf
           weight: 500
@@ -59,14 +59,14 @@ flutter:
           style: italic
     - family: Montserrat
       fonts:
+        - asset: assets/fonts/montserrat/Montserrat-Regular.ttf
+          weight: 400
         - asset: assets/fonts/montserrat/Montserrat-Thin.ttf
           weight: 100
         - asset: assets/fonts/montserrat/Montserrat-ExtraLight.ttf
           weight: 200
         - asset: assets/fonts/montserrat/Montserrat-Light.ttf
           weight: 300
-        - asset: assets/fonts/montserrat/Montserrat-Regular.ttf
-          weight: 400
         - asset: assets/fonts/montserrat/Montserrat-Medium.ttf
           weight: 500
         - asset: assets/fonts/montserrat/Montserrat-SemiBold.ttf
@@ -77,6 +77,9 @@ flutter:
           weight: 800
         - asset: assets/fonts/montserrat/Montserrat-Black.ttf
           weight: 900
+        - asset: assets/fonts/montserrat/Montserrat-RegularItalic.ttf
+          weight: 400
+          style: italic
         - asset: assets/fonts/montserrat/Montserrat-ThinItalic.ttf
           weight: 100
           style: italic
@@ -85,9 +88,6 @@ flutter:
           style: italic
         - asset: assets/fonts/montserrat/Montserrat-LightItalic.ttf
           weight: 300
-          style: italic
-        - asset: assets/fonts/montserrat/Montserrat-RegularItalic.ttf
-          weight: 400
           style: italic
         - asset: assets/fonts/montserrat/Montserrat-MediumItalic.ttf
           weight: 500


### PR DESCRIPTION
This seems to workaround this problem on CanvasKit -- it seems that we pull the first matching definition from pubspec.yaml when a weight isn't explicitly defined. 